### PR TITLE
feat(archive): add concurrency control for archive operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ ghfs [options]
     A download link will appear on top part of the page.
 --archive-max-workers <number>
     Maximum number of concurrent archive operations.
-    Set to -1 for unlimited (default).
+    Set to 0 for unlimited (default).
     When the limit is reached, new archive requests will receive 429 Too Many Requests.
 --archive <url-path> ...
 --archive-user <separator><url-path>[<separator><allowed-username>...] ...

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Will generate executable file "main" in current directory.
 Start server on port 8080, root directory is current working directory:
 ```sh
 ghfs -l 8080
-``` 
+```
 
 Start server on port 8080, root directory is /usr/share/doc:
 ```sh
@@ -258,7 +258,10 @@ ghfs [options]
 -A|--global-archive
     Allow user to download the whole contents of current directory for all url paths.
     A download link will appear on top part of the page.
-    Make sure there is no circular symbol links.
+--max-archive-workers <number>
+    Maximum number of concurrent archive operations.
+    Set to -1 for unlimited (default).
+    When the limit is reached, new archive requests will receive 429 Too Many Requests.
 --archive <url-path> ...
 --archive-user <separator><url-path>[<separator><allowed-username>...] ...
     Allow user to download the whole contents of current directory for specific url paths(and sub paths).
@@ -304,7 +307,7 @@ ghfs [options]
 -S|--show <wildcard> ...
 -SD|--show-dir <wildcard> ...
 -SF|--show-file <wildcard> ...
-    If specified, files or directories match wildcards(except hidden by hide option) will be shown. 
+    If specified, files or directories match wildcards(except hidden by hide option) will be shown.
 
 -H|--hide <wildcard> ...
 -HD|--hide-dir <wildcard> ...

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ ghfs [options]
 -A|--global-archive
     Allow user to download the whole contents of current directory for all url paths.
     A download link will appear on top part of the page.
---max-archive-workers <number>
+--archive-max-workers <number>
     Maximum number of concurrent archive operations.
     Set to -1 for unlimited (default).
     When the limit is reached, new archive requests will receive 429 Too Many Requests.

--- a/src/goNixArgParser/parseResult.go
+++ b/src/goNixArgParser/parseResult.go
@@ -118,6 +118,17 @@ func (r *ParseResult) GetInt(key string) (value int, found bool) {
 	return
 }
 
+func (r *ParseResult) GetInt32(key string) (value int32, found bool) {
+	str, found := r.GetString(key)
+	if !found {
+		return
+	}
+
+	value, err := toInt32(str)
+	found = err == nil
+	return
+}
+
 func (r *ParseResult) GetInt64(key string) (value int64, found bool) {
 	str, found := r.GetString(key)
 	if !found {

--- a/src/goNixArgParser/parseResult.go
+++ b/src/goNixArgParser/parseResult.go
@@ -118,13 +118,13 @@ func (r *ParseResult) GetInt(key string) (value int, found bool) {
 	return
 }
 
-func (r *ParseResult) GetInt32(key string) (value int32, found bool) {
+func (r *ParseResult) GetUint32(key string) (value uint32, found bool) {
 	str, found := r.GetString(key)
 	if !found {
 		return
 	}
 
-	value, err := toInt32(str)
+	value, err := toUint32(str)
 	found = err == nil
 	return
 }

--- a/src/goNixArgParser/util.go
+++ b/src/goNixArgParser/util.go
@@ -81,9 +81,9 @@ func toInts(input []string) ([]int, error) {
 	return output, nil
 }
 
-func toInt32(input string) (int32, error) {
-	v, err := strconv.ParseInt(input, 10, 32)
-	return int32(v), err
+func toUint32(input string) (uint32, error) {
+	v, err := strconv.ParseUint(input, 10, 32)
+	return uint32(v), err
 }
 
 func toInt64(input string) (int64, error) {

--- a/src/goNixArgParser/util.go
+++ b/src/goNixArgParser/util.go
@@ -81,6 +81,11 @@ func toInts(input []string) ([]int, error) {
 	return output, nil
 }
 
+func toInt32(input string) (int32, error) {
+	v, err := strconv.ParseInt(input, 10, 32)
+	return int32(v), err
+}
+
 func toInt64(input string) (int64, error) {
 	return strconv.ParseInt(input, 10, 64)
 }

--- a/src/param/cli.go
+++ b/src/param/cli.go
@@ -148,7 +148,7 @@ func NewCliCmd() *goNixArgParser.Command {
 	err = options.AddFlagValues("archivedirsusers", "--archive-dir-user", "", nil, "file system path that allow archive files for specific users, <sep><fs-path>[<sep><user>...]")
 	serverError.CheckFatal(err)
 
-	err = options.AddFlagValue("maxarchiveworkers", "--max-archive-workers", "", "-1", "maximum number of concurrent archive operations (-1 for unlimited)")
+	err = options.AddFlagValue("archivemaxworkers", "--archive-max-workers", "", "-1", "maximum number of concurrent archive operations (-1 for unlimited)")
 	serverError.CheckFatal(err)
 
 	err = options.AddFlag("globalcors", "--global-cors", "GHFS_GLOBAL_CORS", "enable CORS headers for all directories")
@@ -440,7 +440,7 @@ func CmdResultsToParams(results []*goNixArgParser.ParseResult) (params Params, e
 		archiveDirsUsers, _ := result.GetStrings("archivedirsusers")
 		param.ArchiveDirsUsers = SplitAllKeyValues(archiveDirsUsers)
 
-		param.ArchiveMaxWorkers, _ = result.GetInt("maxarchiveworkers")
+		param.ArchiveMaxWorkers, _ = result.GetInt("archivemaxworkers")
 
 		// global restrict access
 		if result.HasKey("globalrestrictaccess") {

--- a/src/param/cli.go
+++ b/src/param/cli.go
@@ -440,7 +440,7 @@ func CmdResultsToParams(results []*goNixArgParser.ParseResult) (params Params, e
 		archiveDirsUsers, _ := result.GetStrings("archivedirsusers")
 		param.ArchiveDirsUsers = SplitAllKeyValues(archiveDirsUsers)
 
-		param.ArchiveMaxWorkers, _ = result.GetInt("archivemaxworkers")
+		param.ArchiveMaxWorkers, _ = result.GetInt32("archivemaxworkers")
 
 		// global restrict access
 		if result.HasKey("globalrestrictaccess") {

--- a/src/param/cli.go
+++ b/src/param/cli.go
@@ -148,7 +148,7 @@ func NewCliCmd() *goNixArgParser.Command {
 	err = options.AddFlagValues("archivedirsusers", "--archive-dir-user", "", nil, "file system path that allow archive files for specific users, <sep><fs-path>[<sep><user>...]")
 	serverError.CheckFatal(err)
 
-	err = options.AddFlagValue("archivemaxworkers", "--archive-max-workers", "", "-1", "maximum number of concurrent archive operations (-1 for unlimited)")
+	err = options.AddFlagValue("archivemaxworkers", "--archive-max-workers", "", "0", "maximum number of concurrent archive operations (0 for unlimited)")
 	serverError.CheckFatal(err)
 
 	err = options.AddFlag("globalcors", "--global-cors", "GHFS_GLOBAL_CORS", "enable CORS headers for all directories")
@@ -440,7 +440,7 @@ func CmdResultsToParams(results []*goNixArgParser.ParseResult) (params Params, e
 		archiveDirsUsers, _ := result.GetStrings("archivedirsusers")
 		param.ArchiveDirsUsers = SplitAllKeyValues(archiveDirsUsers)
 
-		param.ArchiveMaxWorkers, _ = result.GetInt32("archivemaxworkers")
+		param.ArchiveMaxWorkers, _ = result.GetUint32("archivemaxworkers")
 
 		// global restrict access
 		if result.HasKey("globalrestrictaccess") {

--- a/src/param/cli.go
+++ b/src/param/cli.go
@@ -2,12 +2,13 @@ package param
 
 import (
 	"errors"
-	"mjpclab.dev/ghfs/src/goNixArgParser"
-	"mjpclab.dev/ghfs/src/goVirtualHost"
-	"mjpclab.dev/ghfs/src/serverError"
 	"net/http"
 	"os"
 	"strings"
+
+	"mjpclab.dev/ghfs/src/goNixArgParser"
+	"mjpclab.dev/ghfs/src/goVirtualHost"
+	"mjpclab.dev/ghfs/src/serverError"
 )
 
 var cliCmd = NewCliCmd()
@@ -145,6 +146,9 @@ func NewCliCmd() *goNixArgParser.Command {
 	serverError.CheckFatal(err)
 
 	err = options.AddFlagValues("archivedirsusers", "--archive-dir-user", "", nil, "file system path that allow archive files for specific users, <sep><fs-path>[<sep><user>...]")
+	serverError.CheckFatal(err)
+
+	err = options.AddFlagValue("maxarchiveworkers", "--max-archive-workers", "", "-1", "maximum number of concurrent archive operations (-1 for unlimited)")
 	serverError.CheckFatal(err)
 
 	err = options.AddFlag("globalcors", "--global-cors", "GHFS_GLOBAL_CORS", "enable CORS headers for all directories")
@@ -436,6 +440,8 @@ func CmdResultsToParams(results []*goNixArgParser.ParseResult) (params Params, e
 		archiveDirsUsers, _ := result.GetStrings("archivedirsusers")
 		param.ArchiveDirsUsers = SplitAllKeyValues(archiveDirsUsers)
 
+		param.ArchiveMaxWorkers, _ = result.GetInt("maxarchiveworkers")
+
 		// global restrict access
 		if result.HasKey("globalrestrictaccess") {
 			param.GlobalRestrictAccess, _ = result.GetStrings("globalrestrictaccess")
@@ -464,7 +470,7 @@ func CmdResultsToParams(results []*goNixArgParser.ParseResult) (params Params, e
 		// certificate
 		certFiles, _ := result.GetStrings("certs")
 		keyFiles, _ := result.GetStrings("keys")
-		param.CertKeyPaths, es = goVirtualHost.CertsKeysToPairs(certFiles, keyFiles)
+		param.CertKeyPaths, _ = goVirtualHost.CertsKeysToPairs(certFiles, keyFiles)
 
 		// listen
 		listens, _ := result.GetStrings("listens")

--- a/src/param/cli.go
+++ b/src/param/cli.go
@@ -470,7 +470,8 @@ func CmdResultsToParams(results []*goNixArgParser.ParseResult) (params Params, e
 		// certificate
 		certFiles, _ := result.GetStrings("certs")
 		keyFiles, _ := result.GetStrings("keys")
-		param.CertKeyPaths, _ = goVirtualHost.CertsKeysToPairs(certFiles, keyFiles)
+		param.CertKeyPaths, es = goVirtualHost.CertsKeysToPairs(certFiles, keyFiles)
+		errs = append(errs, es...)
 
 		// listen
 		listens, _ := result.GetStrings("listens")

--- a/src/param/main.go
+++ b/src/param/main.go
@@ -1,11 +1,12 @@
 package param
 
 import (
+	"os"
+	"path/filepath"
+
 	"mjpclab.dev/ghfs/src/middleware"
 	"mjpclab.dev/ghfs/src/serverError"
 	"mjpclab.dev/ghfs/src/util"
-	"os"
-	"path/filepath"
 )
 
 type Param struct {
@@ -56,11 +57,13 @@ type Param struct {
 	DeleteDirs      []string
 	DeleteDirsUsers [][]string // [][path, user...]
 
-	GlobalArchive    bool
-	ArchiveUrls      []string
-	ArchiveUrlsUsers [][]string // [][path, user...]
-	ArchiveDirs      []string
-	ArchiveDirsUsers [][]string // [][path, user...]
+	GlobalArchive     bool
+	ArchiveUrls       []string
+	ArchiveUrlsUsers  [][]string // [][path, user...]
+	ArchiveDirs       []string
+	ArchiveDirsUsers  [][]string // [][path, user...]
+	ArchiveMaxWorkers int
+	ArchivationsSem   chan struct{}
 
 	GlobalCors bool
 	CorsUrls   []string
@@ -163,6 +166,10 @@ func (param *Param) Normalize() (errs []error) {
 	param.DeleteDirs = NormalizeFsPaths(param.DeleteDirs)
 	param.ArchiveUrls = NormalizeUrlPaths(param.ArchiveUrls)
 	param.ArchiveDirs = NormalizeFsPaths(param.ArchiveDirs)
+	if param.ArchiveMaxWorkers > 0 {
+		param.ArchivationsSem = make(chan struct{}, param.ArchiveMaxWorkers)
+	}
+
 	param.CorsUrls = NormalizeUrlPaths(param.CorsUrls)
 	param.CorsDirs = NormalizeFsPaths(param.CorsDirs)
 

--- a/src/param/main.go
+++ b/src/param/main.go
@@ -165,7 +165,6 @@ func (param *Param) Normalize() (errs []error) {
 	param.DeleteDirs = NormalizeFsPaths(param.DeleteDirs)
 	param.ArchiveUrls = NormalizeUrlPaths(param.ArchiveUrls)
 	param.ArchiveDirs = NormalizeFsPaths(param.ArchiveDirs)
-
 	param.CorsUrls = NormalizeUrlPaths(param.CorsUrls)
 	param.CorsDirs = NormalizeFsPaths(param.CorsDirs)
 

--- a/src/param/main.go
+++ b/src/param/main.go
@@ -62,7 +62,7 @@ type Param struct {
 	ArchiveUrlsUsers  [][]string // [][path, user...]
 	ArchiveDirs       []string
 	ArchiveDirsUsers  [][]string // [][path, user...]
-	ArchiveMaxWorkers int32
+	ArchiveMaxWorkers uint32
 
 	GlobalCors bool
 	CorsUrls   []string

--- a/src/param/main.go
+++ b/src/param/main.go
@@ -62,8 +62,7 @@ type Param struct {
 	ArchiveUrlsUsers  [][]string // [][path, user...]
 	ArchiveDirs       []string
 	ArchiveDirsUsers  [][]string // [][path, user...]
-	ArchiveMaxWorkers int
-	ArchivationsSem   chan struct{}
+	ArchiveMaxWorkers int32
 
 	GlobalCors bool
 	CorsUrls   []string
@@ -166,9 +165,6 @@ func (param *Param) Normalize() (errs []error) {
 	param.DeleteDirs = NormalizeFsPaths(param.DeleteDirs)
 	param.ArchiveUrls = NormalizeUrlPaths(param.ArchiveUrls)
 	param.ArchiveDirs = NormalizeFsPaths(param.ArchiveDirs)
-	if param.ArchiveMaxWorkers > 0 {
-		param.ArchivationsSem = make(chan struct{}, param.ArchiveMaxWorkers)
-	}
 
 	param.CorsUrls = NormalizeUrlPaths(param.CorsUrls)
 	param.CorsDirs = NormalizeFsPaths(param.CorsDirs)

--- a/src/serverHandler/vhostHandler.go
+++ b/src/serverHandler/vhostHandler.go
@@ -3,6 +3,7 @@ package serverHandler
 import (
 	"net/http"
 	"regexp"
+	"sync/atomic"
 
 	"mjpclab.dev/ghfs/src/param"
 	"mjpclab.dev/ghfs/src/serverError"
@@ -30,8 +31,8 @@ type vhostContext struct {
 	archiveUrlsUsers pathIntsList
 	archiveDirsUsers pathIntsList
 
-	archiveMaxWorkers int32
-	archiveWorkers    *int32
+	archiveMaxWorkers uint32
+	archiveWorkers    *atomic.Uint32
 
 	shows     *regexp.Regexp
 	showDirs  *regexp.Regexp
@@ -99,11 +100,6 @@ func NewVhostHandler(
 		theme = defaultTheme.DefaultTheme
 	}
 
-	var archiveMaxWorkers int32
-	if p.ArchiveMaxWorkers > 0 {
-		archiveMaxWorkers = p.ArchiveMaxWorkers
-	}
-
 	// alias param
 	vhostCtx := &vhostContext{
 		logger: logger,
@@ -124,7 +120,7 @@ func NewVhostHandler(
 		archiveDirsUsers: pathUsernamesToPathUids(users, p.ArchiveDirsUsers),
 
 		archiveMaxWorkers: p.ArchiveMaxWorkers,
-		archiveWorkers:    &archiveMaxWorkers,
+		archiveWorkers:    &atomic.Uint32{},
 
 		shows:     shows,
 		showDirs:  showDirs,

--- a/src/serverHandler/vhostHandler.go
+++ b/src/serverHandler/vhostHandler.go
@@ -1,14 +1,15 @@
 package serverHandler
 
 import (
+	"net/http"
+	"regexp"
+
 	"mjpclab.dev/ghfs/src/param"
 	"mjpclab.dev/ghfs/src/serverError"
 	"mjpclab.dev/ghfs/src/serverLog"
 	"mjpclab.dev/ghfs/src/tpl/defaultTheme"
 	"mjpclab.dev/ghfs/src/tpl/theme"
 	"mjpclab.dev/ghfs/src/user"
-	"net/http"
-	"regexp"
 )
 
 type vhostContext struct {
@@ -28,6 +29,9 @@ type vhostContext struct {
 	deleteDirsUsers  pathIntsList
 	archiveUrlsUsers pathIntsList
 	archiveDirsUsers pathIntsList
+
+	archiveMaxWorkers int32
+	archiveWorkers    *int32
 
 	shows     *regexp.Regexp
 	showDirs  *regexp.Regexp
@@ -95,6 +99,11 @@ func NewVhostHandler(
 		theme = defaultTheme.DefaultTheme
 	}
 
+	var archiveMaxWorkers int32
+	if p.ArchiveMaxWorkers > 0 {
+		archiveMaxWorkers = p.ArchiveMaxWorkers
+	}
+
 	// alias param
 	vhostCtx := &vhostContext{
 		logger: logger,
@@ -113,6 +122,9 @@ func NewVhostHandler(
 		deleteDirsUsers:  pathUsernamesToPathUids(users, p.DeleteDirsUsers),
 		archiveUrlsUsers: pathUsernamesToPathUids(users, p.ArchiveUrlsUsers),
 		archiveDirsUsers: pathUsernamesToPathUids(users, p.ArchiveDirsUsers),
+
+		archiveMaxWorkers: p.ArchiveMaxWorkers,
+		archiveWorkers:    &archiveMaxWorkers,
 
 		shows:     shows,
 		showDirs:  showDirs,


### PR DESCRIPTION
Introduce a new `archiveWorkers` channel to limit the number of concurrent archive operations. When the limit is reached, new requests will receive a 429 Too Many Requests response. This prevents resource exhaustion and improves system stability. The maximum number of workers can be configured via the `--max-archive-workers` CLI option. Could be helpful for archiving large files or directories when working with limited resources


![image](https://github.com/user-attachments/assets/cc90c96f-776a-4d9f-a2bf-8f585b014358)
